### PR TITLE
Add F_0.5u and Brier score evaluation metrics

### DIFF
--- a/cli/src/mowen_cli/main.py
+++ b/cli/src/mowen_cli/main.py
@@ -409,6 +409,10 @@ def evaluate(
             out["eer"] = result.eer
         if result.c_at_1 is not None:
             out["c_at_1"] = result.c_at_1
+        if result.f05u is not None:
+            out["f05u"] = result.f05u
+        if result.brier is not None:
+            out["brier"] = result.brier
         typer.echo(json.dumps(out, indent=2))
     else:
         n_docs = sum(fr.total for fr in result.fold_results)
@@ -435,12 +439,20 @@ def evaluate(
         )
 
         # Verification-specific metrics
-        if result.eer is not None or result.c_at_1 is not None:
+        has_verif = any(
+            v is not None for v in
+            (result.eer, result.c_at_1, result.f05u, result.brier)
+        )
+        if has_verif:
             parts = []
             if result.eer is not None:
                 parts.append(f"EER={result.eer:.4f}")
             if result.c_at_1 is not None:
                 parts.append(f"c@1={result.c_at_1:.4f}")
+            if result.f05u is not None:
+                parts.append(f"F0.5u={result.f05u:.4f}")
+            if result.brier is not None:
+                parts.append(f"Brier={result.brier:.4f}")
             typer.echo(f"  Verification: {'  '.join(parts)}")
 
         # Confusion matrix

--- a/core/src/mowen/evaluation.py
+++ b/core/src/mowen/evaluation.py
@@ -75,6 +75,8 @@ class EvaluationResult:
     confusion_matrix: dict[str, dict[str, int]]
     eer: float | None = None
     c_at_1: float | None = None
+    f05u: float | None = None
+    brier: float | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -167,6 +169,89 @@ def _compute_c_at_1(predictions: list[Prediction]) -> float | None:
     return (nc + nu * nc / n) / n if n > 0 else None
 
 
+def _compute_f05u(predictions: list[Prediction]) -> float | None:
+    """Compute F_0.5u metric (Bevendorff et al., 2019).
+
+    A precision-weighted F-measure for verification that rewards leaving
+    hard cases unanswered (score = 0.5).  Non-answers are treated as
+    neither correct nor incorrect but earn a bonus proportional to the
+    overall accuracy.
+
+    For closed-set attribution where all predictions are answered,
+    this equals the standard F_0.5 on the binary correct/incorrect
+    framing.
+    """
+    if not predictions:
+        return None
+
+    n = len(predictions)
+    # Count non-answers: top score is exactly 0.5 (verification abstention)
+    nu = 0
+    if predictions[0].scores:
+        nu = sum(1 for p in predictions if p.scores and p.scores[0][1] == 0.5)
+
+    nc = sum(
+        1 for p in predictions if p.true_author == p.predicted_author
+    )
+    # Answered predictions only
+    n_answered = n - nu
+    if n_answered == 0:
+        # All unanswered — score based on c@1 logic
+        return nc / n if n > 0 else None
+
+    tp = nc
+    fp = n_answered - nc
+    fn = 0  # in the binary framing, fn = missed positives
+
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+    recall = tp / n if n > 0 else 0.0
+
+    beta_sq = 0.25  # beta = 0.5, beta^2 = 0.25
+    if precision + recall == 0:
+        f05 = 0.0
+    else:
+        f05 = (1 + beta_sq) * precision * recall / (beta_sq * precision + recall)
+
+    # Credit for non-answers (same bonus structure as c@1)
+    if n > 0 and nu > 0:
+        answered_acc = nc / n_answered if n_answered > 0 else 0.0
+        f05u = (n_answered * f05 + nu * answered_acc) / n
+    else:
+        f05u = f05
+
+    return f05u
+
+
+def _compute_brier(predictions: list[Prediction]) -> float | None:
+    """Compute complement of Brier score for calibration quality.
+
+    Brier complement = 1 - (1/n) * sum((confidence - label)^2)
+
+    where confidence is the score assigned to the predicted (top-ranked)
+    author, normalized to [0, 1], and label is 1 if the prediction is
+    correct, 0 otherwise.  Higher is better; 1.0 is perfect.
+
+    Returns None if ranking scores are unavailable.
+    """
+    if not predictions or not predictions[0].scores:
+        return None
+
+    n = len(predictions)
+    brier_sum = 0.0
+
+    for p in predictions:
+        if not p.scores:
+            return None
+        # Top-ranked author's score as confidence
+        confidence = p.scores[0][1]
+        # Clamp to [0, 1] for methods that may produce scores outside range
+        confidence = max(0.0, min(1.0, confidence))
+        label = 1.0 if p.true_author == p.predicted_author else 0.0
+        brier_sum += (confidence - label) ** 2
+
+    return 1.0 - brier_sum / n
+
+
 def _compute_metrics(fold_results: list[FoldResult]) -> EvaluationResult:
     """Compute aggregate metrics from fold results."""
     # Flatten predictions
@@ -202,6 +287,8 @@ def _compute_metrics(fold_results: list[FoldResult]) -> EvaluationResult:
 
     eer = _compute_eer(all_preds)
     c1 = _compute_c_at_1(all_preds)
+    f05u = _compute_f05u(all_preds)
+    brier = _compute_brier(all_preds)
 
     return EvaluationResult(
         fold_results=fold_results,
@@ -213,6 +300,8 @@ def _compute_metrics(fold_results: list[FoldResult]) -> EvaluationResult:
         confusion_matrix=cm,
         eer=eer,
         c_at_1=c1,
+        f05u=f05u,
+        brier=brier,
     )
 
 
@@ -422,6 +511,10 @@ def write_results_csv(
             w.writerow(["summary", "eer", f"{result.eer:.6f}"])
         if result.c_at_1 is not None:
             w.writerow(["summary", "c_at_1", f"{result.c_at_1:.6f}"])
+        if result.f05u is not None:
+            w.writerow(["summary", "f05u", f"{result.f05u:.6f}"])
+        if result.brier is not None:
+            w.writerow(["summary", "brier", f"{result.brier:.6f}"])
         w.writerow([])
 
         # Per-author

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -12,8 +12,10 @@ from mowen.evaluation import (
     EvaluationResult,
     FoldResult,
     Prediction,
+    _compute_brier,
     _compute_c_at_1,
     _compute_eer,
+    _compute_f05u,
     _compute_metrics,
     k_fold,
     leave_one_out,
@@ -208,6 +210,111 @@ class TestCAt1:
         result = _compute_metrics(folds)
         assert result.c_at_1 is not None
         assert result.c_at_1 == 1.0
+
+
+# ---------------------------------------------------------------------------
+# F_0.5u metric
+# ---------------------------------------------------------------------------
+
+class TestF05u:
+    def test_perfect_accuracy(self):
+        """All correct predictions yield f05u = 1.0."""
+        preds = [
+            Prediction("d1", "A", "A", (("A", 0.9), ("B", 0.1))),
+            Prediction("d2", "B", "B", (("B", 0.9), ("A", 0.1))),
+        ]
+        f05u = _compute_f05u(preds)
+        assert f05u == pytest.approx(1.0)
+
+    def test_zero_accuracy(self):
+        """All wrong predictions yield f05u = 0.0."""
+        preds = [
+            Prediction("d1", "A", "B", (("B", 0.9), ("A", 0.1))),
+            Prediction("d2", "B", "A", (("A", 0.9), ("B", 0.1))),
+        ]
+        f05u = _compute_f05u(preds)
+        assert f05u == pytest.approx(0.0)
+
+    def test_partial_accuracy(self):
+        """Partial accuracy gives f05u between 0 and 1."""
+        preds = [
+            Prediction("d1", "A", "A", (("A", 0.9),)),
+            Prediction("d2", "A", "B", (("B", 0.9),)),
+            Prediction("d3", "B", "B", (("B", 0.9),)),
+            Prediction("d4", "B", "B", (("B", 0.9),)),
+        ]
+        f05u = _compute_f05u(preds)
+        assert f05u is not None
+        assert 0.0 < f05u < 1.0
+
+    def test_none_for_empty(self):
+        assert _compute_f05u([]) is None
+
+    def test_in_compute_metrics(self):
+        preds = [
+            Prediction("d1", "A", "A", (("A", 0.9),)),
+            Prediction("d2", "B", "B", (("B", 0.9),)),
+        ]
+        folds = [FoldResult(fold_index=0, predictions=preds)]
+        result = _compute_metrics(folds)
+        assert result.f05u is not None
+        assert result.f05u == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Brier score
+# ---------------------------------------------------------------------------
+
+class TestBrier:
+    def test_perfect_with_high_confidence(self):
+        """Correct predictions with high confidence → Brier near 1.0."""
+        preds = [
+            Prediction("d1", "A", "A", (("A", 0.95), ("B", 0.05))),
+            Prediction("d2", "B", "B", (("B", 0.95), ("A", 0.05))),
+        ]
+        brier = _compute_brier(preds)
+        assert brier is not None
+        assert brier > 0.99
+
+    def test_wrong_with_high_confidence(self):
+        """Wrong predictions with high confidence → low Brier."""
+        preds = [
+            Prediction("d1", "A", "B", (("B", 0.95), ("A", 0.05))),
+            Prediction("d2", "B", "A", (("A", 0.95), ("B", 0.05))),
+        ]
+        brier = _compute_brier(preds)
+        assert brier is not None
+        assert brier < 0.2
+
+    def test_uncertain_predictions(self):
+        """Scores near 0.5 give moderate Brier regardless of correctness."""
+        preds = [
+            Prediction("d1", "A", "A", (("A", 0.5), ("B", 0.5))),
+            Prediction("d2", "B", "B", (("B", 0.5), ("A", 0.5))),
+        ]
+        brier = _compute_brier(preds)
+        assert brier is not None
+        assert 0.7 < brier < 0.8  # 1 - 0.5^2 = 0.75
+
+    def test_none_for_empty(self):
+        assert _compute_brier([]) is None
+
+    def test_none_for_no_scores(self):
+        preds = [
+            Prediction("d1", "A", "A", ()),
+            Prediction("d2", "B", "B", ()),
+        ]
+        assert _compute_brier(preds) is None
+
+    def test_in_compute_metrics(self):
+        preds = [
+            Prediction("d1", "A", "A", (("A", 0.9), ("B", 0.1))),
+            Prediction("d2", "B", "B", (("B", 0.9), ("A", 0.1))),
+        ]
+        folds = [FoldResult(fold_index=0, predictions=preds)]
+        result = _compute_metrics(folds)
+        assert result.brier is not None
+        assert result.brier > 0.9
 
 
 # ---------------------------------------------------------------------------

--- a/web/src/pages/ResultsPage.tsx
+++ b/web/src/pages/ResultsPage.tsx
@@ -173,6 +173,70 @@ function computeMRR(evaluated: ExperimentResultResponse[]): number | null {
   return total / evaluated.length;
 }
 
+/**
+ * Compute F_0.5u: precision-weighted F-measure that credits non-answers.
+ * Non-answers are predictions where verification_threshold is set and
+ * the top score equals 0.5.
+ */
+function computeF05u(evaluated: ExperimentResultResponse[]): number | null {
+  if (evaluated.length === 0) return null;
+
+  const n = evaluated.length;
+  let nc = 0;
+  let nu = 0;
+  for (const r of evaluated) {
+    const predicted = r.rankings.length > 0 ? r.rankings[0].author : null;
+    if (predicted === r.unknown_document.author_name) nc++;
+    if (r.verification_threshold != null && r.rankings.length > 0 && r.rankings[0].score === 0.5) nu++;
+  }
+
+  const nAnswered = n - nu;
+  if (nAnswered === 0) return nc / n;
+
+  const tp = nc;
+  const fp = nAnswered - nc;
+  const precision = tp + fp > 0 ? tp / (tp + fp) : 0;
+  const recall = n > 0 ? tp / n : 0;
+  const betaSq = 0.25;
+  const f05 = precision + recall > 0
+    ? (1 + betaSq) * precision * recall / (betaSq * precision + recall)
+    : 0;
+
+  if (nu > 0) {
+    const answeredAcc = nAnswered > 0 ? nc / nAnswered : 0;
+    return (nAnswered * f05 + nu * answeredAcc) / n;
+  }
+  return f05;
+}
+
+/**
+ * Brier score complement: 1 - mean((confidence - label)^2).
+ * Higher is better. Rewards well-calibrated probability outputs.
+ */
+function computeBrier(evaluated: ExperimentResultResponse[]): number | null {
+  if (evaluated.length === 0) return null;
+  // Only compute when scores are available (non-empty rankings)
+  if (evaluated.some((r) => r.rankings.length === 0)) return null;
+
+  const lowerIsBetter = evaluated[0]?.lower_is_better ?? true;
+  let brierSum = 0;
+  for (const r of evaluated) {
+    const trueAuthor = r.unknown_document.author_name!;
+    const predicted = r.rankings[0].author;
+    let confidence = r.rankings[0].score;
+    // For distance-based methods, lower score = more confident,
+    // so we invert by taking 1 - normalized score
+    if (lowerIsBetter) {
+      const maxScore = Math.max(...r.rankings.map((rk) => rk.score));
+      confidence = maxScore > 0 ? 1 - confidence / maxScore : 0;
+    }
+    confidence = Math.max(0, Math.min(1, confidence));
+    const label = predicted === trueAuthor ? 1 : 0;
+    brierSum += (confidence - label) ** 2;
+  }
+  return 1 - brierSum / evaluated.length;
+}
+
 // ---------------------------------------------------------------------------
 // Performance Summary (shown when ground truth is available)
 // ---------------------------------------------------------------------------
@@ -200,6 +264,8 @@ function PerformanceSummary({ results }: { results: ExperimentResultResponse[] }
 
   const auroc = computeAUROC(evaluated);
   const mrr = computeMRR(evaluated);
+  const f05u = computeF05u(evaluated);
+  const brier = computeBrier(evaluated);
 
   // Verification metrics (only when threshold is present)
   const hasVerification = evaluated.some((r) => r.verification_threshold != null);
@@ -248,6 +314,18 @@ function PerformanceSummary({ results }: { results: ExperimentResultResponse[] }
           <div className={s.metricCell}>
             <div className={s.metricValue} style={{ color: 'var(--text)' }}>{mrr.toFixed(3)}</div>
             <div className={s.metricLabel}>MRR</div>
+          </div>
+        )}
+        {f05u != null && (
+          <div className={s.metricCell}>
+            <div className={s.metricValue} style={{ color: 'var(--text)' }}>{f05u.toFixed(3)}</div>
+            <div className={s.metricLabel}>F0.5u</div>
+          </div>
+        )}
+        {brier != null && (
+          <div className={s.metricCell}>
+            <div className={s.metricValue} style={{ color: 'var(--text)' }}>{brier.toFixed(3)}</div>
+            <div className={s.metricLabel}>Brier</div>
           </div>
         )}
         <div className={s.metricCell}>


### PR DESCRIPTION
## Summary
- Add **F_0.5u** (Bevendorff et al. 2019) and **Brier score complement** to complete the PAN-standard 5-metric verification evaluation suite
- Both metrics computed in `evaluation.py`, displayed in CLI, exported in CSV, shown in frontend

## Test plan
- [x] 11 new tests in `test_evaluation.py` (TestF05u + TestBrier)
- [x] Full suite: 731 passed
- [x] Frontend compiles cleanly