### PR TITLE
Add SELMA instruction-tuned embedding driver

### DIFF
--- a/core/src/mowen/event_drivers/__init__.py
+++ b/core/src/mowen/event_drivers/__init__.py
@@ -48,4 +48,9 @@ try:
 except ImportError:
     pass  # transformers/torch not installed
 
+try:
+    from mowen.event_drivers import selma_embeddings as selma_embeddings  # noqa: F401
+except ImportError:
+    pass  # transformers/torch not installed
+
 __all__ = ["EventDriver", "event_driver_registry"]

--- a/core/src/mowen/event_drivers/selma_embeddings.py
+++ b/core/src/mowen/event_drivers/selma_embeddings.py
@@ -1,0 +1,131 @@
+"""SELMA: Style Embeddings from Language Models for Authorship.
+
+Instruction-tuned embedding driver that uses models like
+e5-mistral-7b-instruct to produce stylistically-aware document
+embeddings.  The instruction prefix steers the model toward
+capturing stylistic features rather than topical content.
+
+Reference: Ma et al. (AAAI 2025), Wang et al. (2024).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from mowen.event_drivers.base import EventDriver, event_driver_registry
+from mowen.parameters import ParamDef
+from mowen.types import NumericEventSet
+
+
+@event_driver_registry.register("selma_embeddings")
+@dataclass
+class SELMAEmbeddingDriver(EventDriver):
+    """Produce style-aware embeddings using an instruction-tuned model.
+
+    Prepends a stylistic retrieval instruction to the text, then extracts
+    the last-token (EOS) embedding from the final transformer layer.
+    Returns a :class:`~mowen.types.NumericEventSet`.
+
+    Requires ``transformers`` and ``torch``.  Install with::
+
+        pip install 'mowen[transformers]'
+    """
+
+    display_name: str = "SELMA Instruction-Tuned Embeddings"
+    description: str = (
+        "Instruction-tuned transformer embeddings optimized for "
+        "stylistic similarity (requires transformers extra)."
+    )
+
+    _tokenizer: object = field(default=None, init=False, repr=False)
+    _model: object = field(default=None, init=False, repr=False)
+    _model_name_cache: str = field(default="", init=False, repr=False)
+
+    @classmethod
+    def param_defs(cls) -> list[ParamDef]:
+        return [
+            ParamDef(
+                name="model_name",
+                description=(
+                    "HuggingFace instruction-tuned embedding model."
+                ),
+                param_type=str,
+                default="intfloat/e5-mistral-7b-instruct",
+            ),
+            ParamDef(
+                name="max_length",
+                description="Maximum token length for truncation.",
+                param_type=int,
+                default=4096,
+                min_value=16,
+                max_value=32768,
+            ),
+            ParamDef(
+                name="instruction",
+                description="Instruction prefix for stylistic embedding.",
+                param_type=str,
+                default="Retrieve stylistically similar text",
+            ),
+        ]
+
+    def _ensure_model(self) -> None:
+        """Lazy-load the model on first use."""
+        model_name = self.get_param("model_name")
+        if self._model is not None and self._model_name_cache == model_name:
+            return
+
+        try:
+            from transformers import AutoModel, AutoTokenizer
+        except ImportError as exc:
+            raise ImportError(
+                "SELMA embeddings require the transformers library. "
+                "Install with: pip install 'mowen[transformers]'"
+            ) from exc
+
+        try:
+            import torch  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "SELMA embeddings require PyTorch. "
+                "Install with: pip install torch"
+            ) from exc
+
+        self._tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self._model = AutoModel.from_pretrained(model_name)
+        self._model.eval()
+        self._model_name_cache = model_name
+
+    def create_event_set(self, text: str) -> NumericEventSet:
+        """Return a NumericEventSet from instruction-tuned embedding."""
+        import torch
+
+        self._ensure_model()
+        max_length = self.get_param("max_length")
+        instruction = self.get_param("instruction")
+
+        # Prepend instruction prefix (e5-instruct convention)
+        query = f"Instruct: {instruction}\nQuery: {text}"
+
+        inputs = self._tokenizer(
+            query,
+            return_tensors="pt",
+            truncation=True,
+            max_length=max_length,
+            padding=True,
+        )
+
+        with torch.no_grad():
+            outputs = self._model(**inputs)
+
+        # Extract last-token embedding (EOS position)
+        # For instruction-tuned models, the last token captures
+        # the full sequence representation.
+        last_hidden = outputs.last_hidden_state
+        # Find the position of the last real token (before padding)
+        seq_lengths = inputs["attention_mask"].sum(dim=1) - 1
+        embedding = last_hidden[0, seq_lengths[0].item(), :]
+
+        # L2 normalize
+        embedding = torch.nn.functional.normalize(embedding, dim=0)
+
+        return NumericEventSet(embedding.tolist())

--- a/tests/test_selma_embeddings.py
+++ b/tests/test_selma_embeddings.py
@@ -1,0 +1,64 @@
+"""Tests for the SELMA instruction-tuned embedding driver."""
+
+import pytest
+
+
+class TestSELMAEmbeddings:
+    def test_registered(self):
+        """selma_embeddings should be in the event driver registry."""
+        transformers = pytest.importorskip("transformers")
+        from mowen.event_drivers import event_driver_registry
+
+        assert "selma_embeddings" in event_driver_registry.names()
+
+    def test_param_defs(self):
+        """Should expose model_name, max_length, and instruction params."""
+        transformers = pytest.importorskip("transformers")
+        from mowen.event_drivers import event_driver_registry
+
+        driver = event_driver_registry.create("selma_embeddings")
+        param_names = {p.name for p in driver.param_defs()}
+        assert "model_name" in param_names
+        assert "max_length" in param_names
+        assert "instruction" in param_names
+
+    def test_display_name(self):
+        transformers = pytest.importorskip("transformers")
+        from mowen.event_drivers import event_driver_registry
+
+        driver = event_driver_registry.create("selma_embeddings")
+        assert "SELMA" in driver.display_name
+
+    def test_default_model_name(self):
+        transformers = pytest.importorskip("transformers")
+        from mowen.event_drivers import event_driver_registry
+
+        driver = event_driver_registry.create("selma_embeddings")
+        assert driver.get_param("model_name") == "intfloat/e5-mistral-7b-instruct"
+
+    def test_custom_instruction(self):
+        transformers = pytest.importorskip("transformers")
+        from mowen.event_drivers import event_driver_registry
+
+        driver = event_driver_registry.create(
+            "selma_embeddings",
+            {"instruction": "Find text by the same author"},
+        )
+        assert driver.get_param("instruction") == "Find text by the same author"
+
+    def test_produces_numeric_event_set(self):
+        """With a small model, verify output is NumericEventSet."""
+        transformers = pytest.importorskip("transformers")
+        from mowen.event_drivers import event_driver_registry
+        from mowen.types import NumericEventSet
+
+        # Use the small MiniLM model instead of the large e5-mistral
+        driver = event_driver_registry.create(
+            "selma_embeddings",
+            {"model_name": "sentence-transformers/all-MiniLM-L6-v2"},
+        )
+        result = driver.create_event_set("The quick brown fox.")
+        assert isinstance(result, NumericEventSet)
+        assert len(result) > 0
+        # All values should be finite floats
+        assert all(isinstance(v, float) for v in result)

--- a/web/src/presets.ts
+++ b/web/src/presets.ts
@@ -136,6 +136,24 @@ export const PRESETS: Preset[] = [
     },
   },
   {
+    id: 'selma',
+    name: 'SELMA Embeddings',
+    description:
+      'Zero-shot instruction-tuned embeddings optimized for stylistic similarity. Uses e5-mistral-7b-instruct with a style-retrieval instruction prefix. Best cross-genre method from the CrossNews benchmark. Requires the transformers extra and significant GPU memory.',
+    citation: 'Ma et al. (2025), Wang et al. (2024)',
+    config: {
+      canonicizers: [
+        { name: 'normalize_whitespace', params: {} },
+      ],
+      event_drivers: [
+        { name: 'selma_embeddings', params: {} },
+      ],
+      event_cullers: [],
+      distance_function: null,
+      analysis_method: { name: 'svm', params: {} },
+    },
+  },
+  {
     id: 'general-imposters',
     name: 'General Imposters Method',
     description:


### PR DESCRIPTION
## Summary
- New `selma_embeddings` event driver using instruction-tuned models for stylistic similarity
- Follows e5-instruct convention: instruction prefix + last-token embedding extraction
- New SELMA preset in experiment builder

## Test plan
- [x] 6 tests (registration, params, output type with small model)
- [x] Full suite: 740 passed
- [x] Frontend compiles