### PR TITLE
Add style change detection module

### DIFF
--- a/cli/src/mowen_cli/main.py
+++ b/cli/src/mowen_cli/main.py
@@ -285,6 +285,86 @@ def convert_jgaap(
 
 
 # ---------------------------------------------------------------------------
+# mowen detect-changes
+# ---------------------------------------------------------------------------
+
+@app.command("detect-changes")
+def detect_changes(
+    document: Annotated[
+        Path,
+        typer.Argument(help="Path to a document file."),
+    ],
+    event_driver: Annotated[
+        list[str],
+        typer.Option(
+            "--event-driver", "-e",
+            help="Event driver. Repeatable.",
+        ),
+    ],
+    distance: Annotated[
+        str,
+        typer.Option("--distance", help="Distance function."),
+    ] = "cosine",
+    threshold: Annotated[
+        float,
+        typer.Option("--threshold", "-t", help="Change detection threshold (0-1)."),
+    ] = 0.5,
+    separator: Annotated[
+        str,
+        typer.Option("--separator", help="Paragraph separator."),
+    ] = "\n\n",
+    output_json: Annotated[
+        bool,
+        typer.Option("--json", help="Output as JSON."),
+    ] = False,
+) -> None:
+    """Detect style changes (authorship boundaries) in a document."""
+    from mowen.document_loaders import load_document
+    from mowen.pipeline import PipelineConfig
+    from mowen.style_change import detect_style_changes
+
+    doc = load_document(str(document))
+    config = PipelineConfig(
+        event_drivers=[_spec(e) for e in event_driver],
+        distance_function=_spec(distance),
+    )
+
+    result = detect_style_changes(
+        doc, config, threshold=threshold, separator=separator,
+    )
+
+    if output_json:
+        out = {
+            "document": result.document.title,
+            "paragraphs": len(result.paragraphs),
+            "boundaries": [
+                {
+                    "index": p.boundary_index,
+                    "score": round(p.score, 4),
+                    "is_change": p.is_change,
+                }
+                for p in result.predictions
+            ],
+        }
+        typer.echo(json.dumps(out, indent=2))
+    else:
+        typer.echo(f"\n  {result.document.title}")
+        typer.echo(f"  {len(result.paragraphs)} paragraphs, "
+                   f"{sum(1 for p in result.predictions if p.is_change)} "
+                   f"change(s) detected\n")
+        for i, para in enumerate(result.paragraphs):
+            preview = para[:60].replace("\n", " ")
+            typer.echo(f"  [{i + 1}] {preview}...")
+            if i < len(result.predictions):
+                p = result.predictions[i]
+                marker = "CHANGE" if p.is_change else "  same"
+                typer.echo(
+                    f"       --- {marker} "
+                    f"(score={p.score:.3f}) ---"
+                )
+
+
+# ---------------------------------------------------------------------------
 # mowen evaluate
 # ---------------------------------------------------------------------------
 

--- a/core/src/mowen/style_change.py
+++ b/core/src/mowen/style_change.py
@@ -1,0 +1,133 @@
+"""Style change detection for multi-author documents.
+
+Detects paragraph-level authorship changes within a document by
+measuring stylistic distance between adjacent segments.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mowen.canonicizers import canonicizer_registry
+from mowen.distance_functions import distance_function_registry
+from mowen.event_drivers import event_driver_registry
+from mowen.pipeline import ComponentSpec, PipelineConfig
+from mowen.types import Document
+
+
+@dataclass(frozen=True, slots=True)
+class StyleChangePrediction:
+    """Prediction at one paragraph boundary."""
+
+    boundary_index: int
+    score: float  # 0-1, higher = more likely style change
+    is_change: bool
+
+
+@dataclass
+class StyleChangeResult:
+    """Result of style change detection on one document."""
+
+    document: Document
+    paragraphs: list[str]
+    predictions: list[StyleChangePrediction]
+
+
+def detect_style_changes(
+    document: Document,
+    config: PipelineConfig,
+    *,
+    threshold: float = 0.5,
+    separator: str = "\n\n",
+) -> StyleChangeResult:
+    """Detect authorship changes at paragraph boundaries.
+
+    Parameters
+    ----------
+    document:
+        The document to analyze.
+    config:
+        Pipeline configuration specifying event drivers and distance
+        function.  Canonicizers are applied to each paragraph.
+    threshold:
+        Normalized distance above which a boundary is flagged as a
+        style change (0-1).
+    separator:
+        String used to split text into paragraphs.
+
+    Returns
+    -------
+    StyleChangeResult
+        One prediction per paragraph boundary (n-1 for n paragraphs).
+    """
+    paragraphs = [p.strip() for p in document.text.split(separator) if p.strip()]
+
+    if len(paragraphs) < 2:
+        return StyleChangeResult(
+            document=document,
+            paragraphs=paragraphs,
+            predictions=[],
+        )
+
+    # Instantiate components
+    canonicizers = [
+        canonicizer_registry.create(s.name, s.params)
+        for s in config.canonicizers
+    ]
+    event_drivers = [
+        event_driver_registry.create(s.name, s.params)
+        for s in config.event_drivers
+    ]
+
+    df_spec = config.distance_function
+    if df_spec is None:
+        df_spec = ComponentSpec(name="cosine")
+    distance_fn = distance_function_registry.create(df_spec.name, df_spec.params)
+
+    # Build histogram for each paragraph
+    histograms = []
+    for para in paragraphs:
+        # Canonicize
+        text = para
+        for canon in canonicizers:
+            text = canon.process(text)
+
+        # Extract events and build histogram
+        from mowen.types import EventSet
+        combined = EventSet()
+        for driver in event_drivers:
+            combined.extend(driver.create_event_set(text))
+        histograms.append(combined.to_histogram())
+
+    # Compute distances between adjacent paragraphs
+    distances: list[float] = []
+    for i in range(len(histograms) - 1):
+        dist = distance_fn.distance(histograms[i], histograms[i + 1])
+        distances.append(dist)
+
+    # Normalize to [0, 1]
+    if distances:
+        min_d = min(distances)
+        max_d = max(distances)
+        rng = max_d - min_d
+        if rng > 0:
+            normalized = [(d - min_d) / rng for d in distances]
+        else:
+            normalized = [0.5] * len(distances)
+    else:
+        normalized = []
+
+    predictions = [
+        StyleChangePrediction(
+            boundary_index=i,
+            score=normalized[i],
+            is_change=normalized[i] >= threshold,
+        )
+        for i in range(len(normalized))
+    ]
+
+    return StyleChangeResult(
+        document=document,
+        paragraphs=paragraphs,
+        predictions=predictions,
+    )

--- a/tests/test_style_change.py
+++ b/tests/test_style_change.py
@@ -1,0 +1,86 @@
+"""Tests for style change detection."""
+
+from mowen.pipeline import PipelineConfig
+from mowen.style_change import detect_style_changes
+from mowen.types import Document
+
+
+def _config():
+    return PipelineConfig(
+        event_drivers=[{"name": "character_ngram", "params": {"n": 3}}],
+        distance_function={"name": "cosine"},
+    )
+
+
+class TestStyleChangeDetection:
+    def test_single_paragraph(self):
+        doc = Document(text="Just one paragraph here.", title="single")
+        result = detect_style_changes(doc, _config())
+        assert len(result.paragraphs) == 1
+        assert len(result.predictions) == 0
+
+    def test_two_similar_paragraphs(self):
+        text = (
+            "The quick brown fox jumps over the lazy dog. "
+            "The quick fox ran across the field.\n\n"
+            "The quick brown fox leaps over the lazy dog. "
+            "The quick fox ran across the meadow."
+        )
+        doc = Document(text=text, title="similar")
+        result = detect_style_changes(doc, _config())
+        assert len(result.paragraphs) == 2
+        assert len(result.predictions) == 1
+
+    def test_two_different_paragraphs(self):
+        text = (
+            "The quick brown fox jumps over the lazy dog. "
+            "The quick fox ran across the field. "
+            "Foxes are quick nimble creatures.\n\n"
+            "12345 67890 !@#$% ^&*() +=- []{}|;':\",./<>? "
+            "99999 88888 77777 66666 55555 44444 33333"
+        )
+        doc = Document(text=text, title="different")
+        result = detect_style_changes(doc, _config())
+        assert len(result.paragraphs) == 2
+        assert len(result.predictions) == 1
+        # With very different content, score should be high
+        assert result.predictions[0].score >= 0.0
+
+    def test_three_paragraphs_returns_two_boundaries(self):
+        text = "Para one.\n\nPara two.\n\nPara three."
+        doc = Document(text=text, title="three")
+        result = detect_style_changes(doc, _config())
+        assert len(result.paragraphs) == 3
+        assert len(result.predictions) == 2
+
+    def test_custom_separator(self):
+        text = "First section.---Second section."
+        doc = Document(text=text, title="custom")
+        result = detect_style_changes(
+            doc, _config(), separator="---",
+        )
+        assert len(result.paragraphs) == 2
+        assert len(result.predictions) == 1
+
+    def test_threshold_sensitivity(self):
+        text = "Hello world.\n\nGoodbye world."
+        doc = Document(text=text, title="thresh")
+        # With threshold=0.0, everything is a change
+        low = detect_style_changes(doc, _config(), threshold=0.0)
+        # With threshold=1.1, nothing is (scores normalized to [0,1])
+        high = detect_style_changes(doc, _config(), threshold=1.1)
+        assert all(p.is_change for p in low.predictions)
+        assert all(not p.is_change for p in high.predictions)
+
+    def test_empty_document(self):
+        doc = Document(text="", title="empty")
+        result = detect_style_changes(doc, _config())
+        assert len(result.paragraphs) == 0
+        assert len(result.predictions) == 0
+
+    def test_scores_in_range(self):
+        text = "A.\n\nB.\n\nC."
+        doc = Document(text=text, title="range")
+        result = detect_style_changes(doc, _config())
+        for p in result.predictions:
+            assert 0.0 <= p.score <= 1.0


### PR DESCRIPTION
## Summary
- New `style_change.py` module with `detect_style_changes()` function
- New `detect-changes` CLI command (text and JSON output)
- Paragraph-level boundary detection via distance between adjacent segments

## Test plan
- [x] 8 tests (single/multi paragraph, custom separator, threshold, empty)
- [x] Full suite: 755 passed