### PR TITLE
Add perplexity / surprisal event driver

### DIFF
--- a/core/src/mowen/event_drivers/__init__.py
+++ b/core/src/mowen/event_drivers/__init__.py
@@ -53,4 +53,9 @@ try:
 except ImportError:
     pass  # transformers/torch not installed
 
+try:
+    from mowen.event_drivers import perplexity as perplexity  # noqa: F401
+except ImportError:
+    pass  # transformers/torch not installed
+
 __all__ = ["EventDriver", "event_driver_registry"]

--- a/core/src/mowen/event_drivers/perplexity.py
+++ b/core/src/mowen/event_drivers/perplexity.py
@@ -1,0 +1,144 @@
+"""Perplexity / surprisal feature extraction from causal language models.
+
+Computes per-token negative log-likelihood (surprisal) statistics using a
+causal LM (GPT-2 by default).  The summary statistics (mean, variance,
+skewness, kurtosis) capture a document's predictability profile, which
+varies by author.
+
+Reference: Basani & Chen (PAN 2025), Sun et al. (PAN 2025).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+from mowen.event_drivers.base import EventDriver, event_driver_registry
+from mowen.parameters import ParamDef
+from mowen.types import NumericEventSet
+
+
+def _statistics(values: list[float]) -> tuple[float, float, float, float]:
+    """Compute mean, variance, skewness, kurtosis (pure Python)."""
+    n = len(values)
+    if n == 0:
+        return (0.0, 0.0, 0.0, 0.0)
+
+    mean = sum(values) / n
+    if n < 2:
+        return (mean, 0.0, 0.0, 0.0)
+
+    var = sum((x - mean) ** 2 for x in values) / n
+    std = math.sqrt(var) if var > 0 else 1e-12
+
+    skew = sum(((x - mean) / std) ** 3 for x in values) / n
+    kurt = sum(((x - mean) / std) ** 4 for x in values) / n - 3.0
+
+    return (mean, var, skew, kurt)
+
+
+@event_driver_registry.register("perplexity")
+@dataclass
+class PerplexityDriver(EventDriver):
+    """Extract surprisal statistics from a causal language model.
+
+    Returns a :class:`~mowen.types.NumericEventSet` with 4 features:
+    mean, variance, skewness, and kurtosis of per-token surprisal
+    (negative log-likelihood).
+
+    Requires ``transformers`` and ``torch``.  Install with::
+
+        pip install 'mowen[transformers]'
+    """
+
+    display_name: str = "Perplexity / Surprisal Features"
+    description: str = (
+        "Statistical features of per-token surprisal from a causal "
+        "language model (requires transformers extra)."
+    )
+
+    _tokenizer: object = field(default=None, init=False, repr=False)
+    _model: object = field(default=None, init=False, repr=False)
+    _model_name_cache: str = field(default="", init=False, repr=False)
+
+    @classmethod
+    def param_defs(cls) -> list[ParamDef]:
+        return [
+            ParamDef(
+                name="model_name",
+                description="HuggingFace causal language model.",
+                param_type=str,
+                default="gpt2",
+            ),
+            ParamDef(
+                name="max_length",
+                description="Maximum token length per chunk.",
+                param_type=int,
+                default=1024,
+                min_value=16,
+                max_value=4096,
+            ),
+        ]
+
+    def _ensure_model(self) -> None:
+        """Lazy-load the causal LM on first use."""
+        model_name = self.get_param("model_name")
+        if self._model is not None and self._model_name_cache == model_name:
+            return
+
+        try:
+            from transformers import AutoModelForCausalLM, AutoTokenizer
+        except ImportError as exc:
+            raise ImportError(
+                "Perplexity features require the transformers library. "
+                "Install with: pip install 'mowen[transformers]'"
+            ) from exc
+
+        try:
+            import torch  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "Perplexity features require PyTorch. "
+                "Install with: pip install torch"
+            ) from exc
+
+        self._tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self._model = AutoModelForCausalLM.from_pretrained(model_name)
+        self._model.eval()
+        self._model_name_cache = model_name
+
+    def create_event_set(self, text: str) -> NumericEventSet:
+        """Return a NumericEventSet of surprisal statistics."""
+        import torch
+
+        self._ensure_model()
+        max_length = self.get_param("max_length")
+
+        inputs = self._tokenizer(
+            text,
+            return_tensors="pt",
+            truncation=True,
+            max_length=max_length,
+        )
+
+        input_ids = inputs["input_ids"]
+
+        with torch.no_grad():
+            outputs = self._model(**inputs)
+            logits = outputs.logits  # (1, seq_len, vocab_size)
+
+        # Compute per-token surprisal (shifted by 1 for causal LM)
+        # logits[0, t, :] predicts token at position t+1
+        surprisals: list[float] = []
+        log_probs = torch.nn.functional.log_softmax(logits[0], dim=-1)
+
+        for t in range(input_ids.size(1) - 1):
+            next_token = input_ids[0, t + 1].item()
+            token_log_prob = log_probs[t, next_token].item()
+            surprisals.append(-token_log_prob)
+
+        if not surprisals:
+            return NumericEventSet([0.0, 0.0, 0.0, 0.0])
+
+        mean, var, skew, kurt = _statistics(surprisals)
+        return NumericEventSet([mean, var, skew, kurt])

--- a/tests/test_perplexity.py
+++ b/tests/test_perplexity.py
@@ -1,0 +1,69 @@
+"""Tests for the perplexity / surprisal event driver."""
+
+import pytest
+
+
+class TestPerplexityDriver:
+    def test_registered(self):
+        pytest.importorskip("transformers")
+        from mowen.event_drivers import event_driver_registry
+
+        assert "perplexity" in event_driver_registry.names()
+
+    def test_param_defs(self):
+        pytest.importorskip("transformers")
+        from mowen.event_drivers import event_driver_registry
+
+        driver = event_driver_registry.create("perplexity")
+        param_names = {p.name for p in driver.param_defs()}
+        assert "model_name" in param_names
+        assert "max_length" in param_names
+
+    def test_default_model(self):
+        pytest.importorskip("transformers")
+        from mowen.event_drivers import event_driver_registry
+
+        driver = event_driver_registry.create("perplexity")
+        assert driver.get_param("model_name") == "gpt2"
+
+    def test_produces_four_features(self):
+        pytest.importorskip("transformers")
+        from mowen.event_drivers import event_driver_registry
+        from mowen.types import NumericEventSet
+
+        driver = event_driver_registry.create("perplexity")
+        result = driver.create_event_set(
+            "The quick brown fox jumps over the lazy dog."
+        )
+        assert isinstance(result, NumericEventSet)
+        assert len(result) == 4  # mean, variance, skewness, kurtosis
+
+    def test_different_texts_different_features(self):
+        pytest.importorskip("transformers")
+        from mowen.event_drivers import event_driver_registry
+
+        driver = event_driver_registry.create("perplexity")
+        r1 = driver.create_event_set(
+            "The quick brown fox jumps over the lazy dog."
+        )
+        r2 = driver.create_event_set(
+            "xyzzy plugh zork quux corge grault garply"
+        )
+        # At least one feature should differ
+        assert any(a != b for a, b in zip(r1, r2))
+
+
+def test_statistics_helper():
+    """Test the pure-Python statistics function."""
+    from mowen.event_drivers.perplexity import _statistics
+
+    mean, var, skew, kurt = _statistics([1.0, 2.0, 3.0, 4.0, 5.0])
+    assert abs(mean - 3.0) < 1e-6
+    assert var > 0
+    # Empty input
+    m, v, s, k = _statistics([])
+    assert m == 0.0
+    # Single value
+    m, v, s, k = _statistics([42.0])
+    assert m == 42.0
+    assert v == 0.0


### PR DESCRIPTION
## Summary
- New `perplexity` event driver extracting surprisal statistics from causal LMs
- 4 features: mean, variance, skewness, kurtosis of per-token surprisal
- Uses GPT-2 by default, configurable model

## Test plan
- [x] 6 tests (registration, params, output shape, differentiation, helper)
- [x] Full suite: 768 passed