### PR TITLE
Add R-Drop regularization to MLP analysis method

### DIFF
--- a/core/src/mowen/analysis_methods/mlp.py
+++ b/core/src/mowen/analysis_methods/mlp.py
@@ -1,13 +1,23 @@
-"""Multilayer Perceptron (neural network) analysis method."""
+"""Multilayer Perceptron (neural network) analysis method.
+
+Supports optional R-Drop regularization (torch-based) for improved
+robustness.  When ``r_drop=False`` (default), uses scikit-learn's
+MLPClassifier.  When ``r_drop=True``, trains a simple torch MLP with
+R-Drop (Regularized Dropout) loss.
+
+Reference for R-Drop: Liang et al. (NeurIPS 2021).
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from mowen.analysis_methods.base import analysis_method_registry
 from mowen.analysis_methods.sklearn_base import SklearnAnalysisMethod
+from mowen.exceptions import PipelineError
 from mowen.parameters import ParamDef
+from mowen.types import Attribution, Document, Event, Histogram, NumericEventSet
 
 
 @analysis_method_registry.register("mlp")
@@ -18,7 +28,8 @@ class MultilayerPerceptron(SklearnAnalysisMethod):
     A feedforward neural network with configurable hidden layer size.
     Capable of learning non-linear decision boundaries.
 
-    Requires ``scikit-learn`` to be installed.
+    With ``r_drop=True``, uses a torch-based MLP trained with R-Drop
+    regularization (requires torch).  Otherwise uses scikit-learn.
 
     Score semantics: higher = better match (probability-based).
     """
@@ -26,8 +37,14 @@ class MultilayerPerceptron(SklearnAnalysisMethod):
     display_name: str = "Multilayer Perceptron"
     description: str = (
         "Assigns authorship using a neural network "
-        "(requires scikit-learn)."
+        "(requires scikit-learn; optionally torch for R-Drop)."
     )
+
+    _torch_model: Any = field(default=None, init=False, repr=False)
+    _torch_classes: list[str] = field(
+        default_factory=list, init=False, repr=False,
+    )
+    _rdrop_active: bool = field(default=False, init=False, repr=False)
 
     @classmethod
     def param_defs(cls) -> list[ParamDef]:
@@ -48,6 +65,39 @@ class MultilayerPerceptron(SklearnAnalysisMethod):
                 min_value=10,
                 max_value=5000,
             ),
+            ParamDef(
+                name="r_drop",
+                description=(
+                    "Enable R-Drop regularization (requires torch). "
+                    "When disabled, uses scikit-learn MLPClassifier."
+                ),
+                param_type=bool,
+                default=False,
+            ),
+            ParamDef(
+                name="r_drop_alpha",
+                description="Weight of R-Drop KL divergence loss.",
+                param_type=float,
+                default=1.0,
+                min_value=0.0,
+                max_value=100.0,
+            ),
+            ParamDef(
+                name="dropout",
+                description="Dropout rate for R-Drop MLP.",
+                param_type=float,
+                default=0.3,
+                min_value=0.0,
+                max_value=0.9,
+            ),
+            ParamDef(
+                name="learning_rate",
+                description="Learning rate for R-Drop optimizer.",
+                param_type=float,
+                default=0.001,
+                min_value=1e-6,
+                max_value=1.0,
+            ),
         ]
 
     def _create_model(self) -> Any:
@@ -59,3 +109,135 @@ class MultilayerPerceptron(SklearnAnalysisMethod):
             hidden_layer_sizes=(hidden_size,),
             max_iter=max_iter,
         )
+
+    def train(self, known_docs: list[tuple[Document, Histogram]]) -> None:
+        """Train with sklearn or R-Drop torch path."""
+        r_drop: bool = self.get_param("r_drop")
+
+        if not r_drop:
+            # Standard sklearn path
+            self._rdrop_active = False
+            super().train(known_docs)
+            return
+
+        # R-Drop torch path
+        self._rdrop_active = True
+        self._known_docs = list(known_docs)
+
+        try:
+            import torch
+            import torch.nn as nn
+        except ImportError as exc:
+            raise ImportError(
+                "R-Drop regularization requires PyTorch. "
+                "Install with: pip install torch"
+            ) from exc
+
+        # Detect numeric mode and build feature matrix
+        self._numeric_mode = any(
+            isinstance(hist, NumericEventSet)
+            for _, hist in self._known_docs
+        )
+
+        x_list: list[list[float]] = []
+        y_list: list[str] = []
+
+        if self._numeric_mode:
+            for doc, hist in self._known_docs:
+                x_list.append(list(hist))
+                y_list.append(doc.author or "")
+        else:
+            vocab_set: set[Event] = set()
+            for _, hist in self._known_docs:
+                vocab_set.update(hist.unique_events())
+            self._vocabulary = sorted(vocab_set, key=lambda e: e.data)
+            for doc, hist in self._known_docs:
+                x_list.append(self._vectorize(hist, self._vocabulary))
+                y_list.append(doc.author or "")
+
+        # Encode labels
+        unique_authors = sorted(set(y_list))
+        self._torch_classes = unique_authors
+        label_map = {a: i for i, a in enumerate(unique_authors)}
+        y_encoded = [label_map[a] for a in y_list]
+
+        input_dim = len(x_list[0])
+        n_classes = len(unique_authors)
+        hidden_size: int = self.get_param("hidden_size")
+        dropout: float = self.get_param("dropout")
+        alpha: float = self.get_param("r_drop_alpha")
+        lr: float = self.get_param("learning_rate")
+        max_iter: int = self.get_param("max_iter")
+
+        # Build torch model
+        model = nn.Sequential(
+            nn.Linear(input_dim, hidden_size),
+            nn.ReLU(),
+            nn.Dropout(dropout),
+            nn.Linear(hidden_size, n_classes),
+        )
+
+        x_tensor = torch.tensor(x_list, dtype=torch.float32)
+        y_tensor = torch.tensor(y_encoded, dtype=torch.long)
+
+        optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+        ce_loss = nn.CrossEntropyLoss()
+
+        for _ in range(max_iter):
+            model.train()
+
+            # Double forward pass (different dropout masks)
+            logits1 = model(x_tensor)
+            logits2 = model(x_tensor)
+
+            loss1 = ce_loss(logits1, y_tensor)
+            loss2 = ce_loss(logits2, y_tensor)
+
+            # KL divergence between the two distributions
+            p1 = torch.nn.functional.softmax(logits1, dim=-1)
+            p2 = torch.nn.functional.softmax(logits2, dim=-1)
+            kl_1 = torch.nn.functional.kl_div(
+                p1.log(), p2, reduction="batchmean",
+            )
+            kl_2 = torch.nn.functional.kl_div(
+                p2.log(), p1, reduction="batchmean",
+            )
+            kl_loss = (kl_1 + kl_2) / 2
+
+            total_loss = (loss1 + loss2) / 2 + alpha * kl_loss
+
+            optimizer.zero_grad()
+            total_loss.backward()
+            optimizer.step()
+
+        model.eval()
+        self._torch_model = model
+
+    def analyze(self, unknown_histogram: Histogram) -> list[Attribution]:
+        """Return attributions from sklearn or torch model."""
+        if not self._rdrop_active:
+            return super().analyze(unknown_histogram)
+
+        import torch
+
+        if self._torch_model is None:
+            raise PipelineError(
+                "train() must be called before analyze()"
+            )
+
+        if self._numeric_mode:
+            vec = list(unknown_histogram)
+        else:
+            vec = self._vectorize(unknown_histogram, self._vocabulary)
+
+        x = torch.tensor([vec], dtype=torch.float32)
+        with torch.no_grad():
+            logits = self._torch_model(x)
+            probs = torch.nn.functional.softmax(logits, dim=-1)[0]
+
+        attributions = [
+            Attribution(author=author, score=float(probs[i]))
+            for i, author in enumerate(self._torch_classes)
+        ]
+        attributions.sort(key=lambda a: a.score, reverse=True)
+        return attributions

--- a/tests/test_mlp_rdrop.py
+++ b/tests/test_mlp_rdrop.py
@@ -1,0 +1,92 @@
+"""Tests for MLP with R-Drop regularization."""
+
+import pytest
+
+from mowen.analysis_methods import analysis_method_registry
+from mowen.types import Document, Event, Histogram, NumericEventSet
+
+
+def _make_training_data():
+    return [
+        (Document(text="", author="A", title="a1"),
+         Histogram({Event("a"): 5, Event("b"): 1})),
+        (Document(text="", author="A", title="a2"),
+         Histogram({Event("a"): 4, Event("b"): 2})),
+        (Document(text="", author="B", title="b1"),
+         Histogram({Event("a"): 1, Event("b"): 5})),
+        (Document(text="", author="B", title="b2"),
+         Histogram({Event("a"): 2, Event("b"): 4})),
+    ]
+
+
+def _make_numeric_data():
+    return [
+        (Document(text="", author="A", title="a1"),
+         NumericEventSet([1.0, 0.0, 0.5])),
+        (Document(text="", author="A", title="a2"),
+         NumericEventSet([0.9, 0.1, 0.6])),
+        (Document(text="", author="B", title="b1"),
+         NumericEventSet([0.0, 1.0, 0.5])),
+        (Document(text="", author="B", title="b2"),
+         NumericEventSet([0.1, 0.9, 0.4])),
+    ]
+
+
+class TestMLPRDrop:
+    def test_rdrop_disabled_uses_sklearn(self):
+        """Default r_drop=False should work normally."""
+        pytest.importorskip("sklearn")
+        method = analysis_method_registry.create(
+            "mlp", {"r_drop": False, "max_iter": 100}
+        )
+        method.train(_make_training_data())
+        unknown = Histogram({Event("a"): 6, Event("b"): 1})
+        results = method.analyze(unknown)
+        assert results[0].author == "A"
+        assert len(results) == 2
+
+    def test_rdrop_enabled_with_histograms(self):
+        torch = pytest.importorskip("torch")
+        method = analysis_method_registry.create(
+            "mlp", {"r_drop": True, "max_iter": 100, "hidden_size": 16}
+        )
+        method.train(_make_training_data())
+        unknown = Histogram({Event("a"): 6, Event("b"): 1})
+        results = method.analyze(unknown)
+        assert results[0].author == "A"
+        assert len(results) == 2
+
+    def test_rdrop_enabled_with_numeric(self):
+        torch = pytest.importorskip("torch")
+        method = analysis_method_registry.create(
+            "mlp", {"r_drop": True, "max_iter": 500, "hidden_size": 16}
+        )
+        method.train(_make_numeric_data())
+        unknown = NumericEventSet([0.85, 0.1, 0.5])
+        results = method.analyze(unknown)
+        assert results[0].author == "A"
+
+    def test_rdrop_scores_are_probabilities(self):
+        torch = pytest.importorskip("torch")
+        method = analysis_method_registry.create(
+            "mlp", {"r_drop": True, "max_iter": 50, "hidden_size": 8}
+        )
+        method.train(_make_training_data())
+        unknown = Histogram({Event("a"): 3, Event("b"): 3})
+        results = method.analyze(unknown)
+        for r in results:
+            assert 0.0 <= r.score <= 1.0
+        # Probabilities should sum to ~1
+        total = sum(r.score for r in results)
+        assert abs(total - 1.0) < 0.01
+
+    def test_rdrop_all_authors_present(self):
+        torch = pytest.importorskip("torch")
+        method = analysis_method_registry.create(
+            "mlp", {"r_drop": True, "max_iter": 50}
+        )
+        method.train(_make_training_data())
+        unknown = Histogram({Event("a"): 3, Event("b"): 3})
+        results = method.analyze(unknown)
+        authors = {r.author for r in results}
+        assert authors == {"A", "B"}


### PR DESCRIPTION
## Summary
- MLP gains `r_drop` param for optional torch-based R-Drop training
- Double forward pass + KL divergence regularization
- Falls back to sklearn when r_drop=False (backward compatible)

## Test plan
- [x] 5 tests (sklearn path, R-Drop histograms, R-Drop numeric, probabilities, all authors)
- [x] Full suite: 781 passed