### PR TITLE
Add cross-genre evaluation protocol

### DIFF
--- a/cli/src/mowen_cli/main.py
+++ b/cli/src/mowen_cli/main.py
@@ -418,6 +418,14 @@ def evaluate(
         Path | None,
         typer.Option("--base-dir", help="Base directory for resolving relative paths in CSV."),
     ] = None,
+    train_genre: Annotated[
+        str | None,
+        typer.Option("--train-genre", help="Genre to train on (cross-genre mode). CSV must have genre column."),
+    ] = None,
+    test_genre: Annotated[
+        str | None,
+        typer.Option("--test-genre", help="Genre to test on (cross-genre mode)."),
+    ] = None,
 ) -> None:
     """Evaluate pipeline accuracy via cross-validation."""
     from mowen.compat.jgaap_csv import load_jgaap_csv
@@ -449,7 +457,13 @@ def evaluate(
 
     # Run evaluation
     try:
-        if mode == "loo":
+        if train_genre and test_genre:
+            from mowen.evaluation import cross_genre_evaluate
+            result = cross_genre_evaluate(
+                known, config, train_genre, test_genre,
+                progress_callback=progress_cb,
+            )
+        elif mode == "loo":
             result = loo_eval(known, config, progress_callback=progress_cb)
         elif mode == "kfold":
             result = kfold_eval(

--- a/core/src/mowen/compat/jgaap_csv.py
+++ b/core/src/mowen/compat/jgaap_csv.py
@@ -59,6 +59,11 @@ def load_jgaap_csv(
 
             doc = load_document(str(doc_path), author=author)
 
+            # Optional 3rd column: genre metadata
+            genre = row[2].strip() if len(row) > 2 and row[2].strip() else None
+            if genre:
+                doc.metadata["genre"] = genre
+
             if author:
                 known.append(doc)
             else:

--- a/core/src/mowen/evaluation.py
+++ b/core/src/mowen/evaluation.py
@@ -486,6 +486,95 @@ def k_fold(
 
 
 # ---------------------------------------------------------------------------
+# Cross-genre evaluation
+# ---------------------------------------------------------------------------
+
+
+def cross_genre_evaluate(
+    documents: list[Document],
+    config: PipelineConfig,
+    train_genre: str,
+    test_genre: str,
+    *,
+    progress_callback: ProgressCallback | None = None,
+) -> EvaluationResult:
+    """Evaluate across genres: train on one genre, test on another.
+
+    Documents must have ``metadata["genre"]`` set.  Authors must appear
+    in both genres.
+
+    Parameters
+    ----------
+    documents:
+        All documents with genre metadata.
+    config:
+        Pipeline configuration.
+    train_genre:
+        Genre to use for training.
+    test_genre:
+        Genre to use for testing.
+    progress_callback:
+        Optional ``(fraction, message)`` callback.
+
+    Returns
+    -------
+    EvaluationResult
+        Single-fold result from cross-genre evaluation.
+    """
+    train_docs = [
+        d for d in documents if d.metadata.get("genre") == train_genre
+    ]
+    test_docs = [
+        d for d in documents if d.metadata.get("genre") == test_genre
+    ]
+
+    if not train_docs:
+        raise EvaluationError(
+            f"No documents found with genre {train_genre!r}"
+        )
+    if not test_docs:
+        raise EvaluationError(
+            f"No documents found with genre {test_genre!r}"
+        )
+
+    # Validate all docs have authors
+    for doc in train_docs + test_docs:
+        if not doc.author:
+            raise EvaluationError(
+                f"Document {doc.title!r} has no author"
+            )
+
+    train_authors = {d.author for d in train_docs}
+    test_authors = {d.author for d in test_docs}
+    shared = train_authors & test_authors
+
+    if len(shared) < 2:
+        raise EvaluationError(
+            f"Need >= 2 shared authors across genres, "
+            f"found {len(shared)}: {shared}"
+        )
+
+    # Filter to shared authors only
+    train_docs = [d for d in train_docs if d.author in shared]
+    test_docs = [d for d in test_docs if d.author in shared]
+
+    if progress_callback:
+        progress_callback(0.0, "Cross-genre evaluation")
+
+    results = Pipeline(config).execute(train_docs, test_docs)
+
+    preds = [
+        _make_prediction(r, test_docs[i].author or "")
+        for i, r in enumerate(results)
+    ]
+
+    if progress_callback:
+        progress_callback(1.0, "Evaluation complete")
+
+    return _compute_metrics([FoldResult(fold_index=0, predictions=preds)])
+
+
+# ---------------------------------------------------------------------------
 # CSV export
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cross_genre.py
+++ b/tests/test_cross_genre.py
@@ -1,0 +1,112 @@
+"""Tests for cross-genre evaluation."""
+
+import pytest
+
+from mowen.evaluation import cross_genre_evaluate
+from mowen.exceptions import EvaluationError
+from mowen.pipeline import PipelineConfig
+from mowen.types import Document
+
+
+def _config():
+    return PipelineConfig(
+        event_drivers=[{"name": "character_ngram", "params": {"n": 3}}],
+        distance_function={"name": "cosine"},
+        analysis_method={"name": "nearest_neighbor"},
+    )
+
+
+def _make_cross_genre_docs():
+    """Two genres (formal/informal), two authors, multiple docs each."""
+    return [
+        Document(
+            text="The government requires strong institutions.",
+            author="Hamilton", title="h_formal1",
+            metadata={"genre": "formal"},
+        ),
+        Document(
+            text="Federal power ensures national defense.",
+            author="Hamilton", title="h_formal2",
+            metadata={"genre": "formal"},
+        ),
+        Document(
+            text="Separation of powers prevents tyranny.",
+            author="Madison", title="m_formal1",
+            metadata={"genre": "formal"},
+        ),
+        Document(
+            text="A republic guards against faction dangers.",
+            author="Madison", title="m_formal2",
+            metadata={"genre": "formal"},
+        ),
+        Document(
+            text="gov needs to be strong, institutions matter!",
+            author="Hamilton", title="h_informal1",
+            metadata={"genre": "informal"},
+        ),
+        Document(
+            text="we need federal power for defense!",
+            author="Hamilton", title="h_informal2",
+            metadata={"genre": "informal"},
+        ),
+        Document(
+            text="separation of powers stops tyranny imo",
+            author="Madison", title="m_informal1",
+            metadata={"genre": "informal"},
+        ),
+        Document(
+            text="republic keeps factions in check tbh",
+            author="Madison", title="m_informal2",
+            metadata={"genre": "informal"},
+        ),
+    ]
+
+
+class TestCrossGenreEvaluation:
+    def test_basic_cross_genre(self):
+        docs = _make_cross_genre_docs()
+        result = cross_genre_evaluate(
+            docs, _config(), "formal", "informal",
+        )
+        assert result is not None
+        assert 0.0 <= result.accuracy <= 1.0
+        assert len(result.per_author) == 2
+
+    def test_missing_genre_raises(self):
+        docs = _make_cross_genre_docs()
+        with pytest.raises(EvaluationError, match="No documents"):
+            cross_genre_evaluate(
+                docs, _config(), "formal", "nonexistent",
+            )
+
+    def test_no_shared_authors_raises(self):
+        docs = [
+            Document(
+                text="text", author="OnlyFormal", title="f1",
+                metadata={"genre": "formal"},
+            ),
+            Document(
+                text="text", author="OnlyFormal", title="f2",
+                metadata={"genre": "formal"},
+            ),
+            Document(
+                text="text", author="OnlyInformal", title="i1",
+                metadata={"genre": "informal"},
+            ),
+            Document(
+                text="text", author="OnlyInformal", title="i2",
+                metadata={"genre": "informal"},
+            ),
+        ]
+        with pytest.raises(EvaluationError, match="shared authors"):
+            cross_genre_evaluate(
+                docs, _config(), "formal", "informal",
+            )
+
+    def test_all_authors_in_results(self):
+        docs = _make_cross_genre_docs()
+        result = cross_genre_evaluate(
+            docs, _config(), "formal", "informal",
+        )
+        authors = {a.author for a in result.per_author}
+        assert authors == {"Hamilton", "Madison"}


### PR DESCRIPTION
## Summary
- New `cross_genre_evaluate()` function for train-on-genre-A, test-on-genre-B
- CSV loader supports optional 3rd column as genre metadata
- CLI `--train-genre` / `--test-genre` options

## Test plan
- [x] 4 tests (basic, missing genre, no shared authors, all authors present)
- [x] Full suite: 785 passed