### PR TITLE
Add topic-controlled evaluation

### DIFF
--- a/cli/src/mowen_cli/main.py
+++ b/cli/src/mowen_cli/main.py
@@ -426,6 +426,14 @@ def evaluate(
         str | None,
         typer.Option("--test-genre", help="Genre to test on (cross-genre mode)."),
     ] = None,
+    topic_controlled: Annotated[
+        bool,
+        typer.Option("--topic-controlled", help="Run topic-controlled evaluation (CSV needs topic column in metadata)."),
+    ] = False,
+    topic_key: Annotated[
+        str,
+        typer.Option("--topic-key", help="Metadata key for topic labels."),
+    ] = "topic",
 ) -> None:
     """Evaluate pipeline accuracy via cross-validation."""
     from mowen.compat.jgaap_csv import load_jgaap_csv
@@ -457,7 +465,35 @@ def evaluate(
 
     # Run evaluation
     try:
-        if train_genre and test_genre:
+        if topic_controlled:
+            from mowen.evaluation import topic_controlled_evaluate
+            tc_result = topic_controlled_evaluate(
+                known, config, topic_key=topic_key,
+                progress_callback=progress_cb,
+            )
+            # Display topic-controlled results and exit early
+            if progress_cb:
+                typer.echo("", err=True)
+            if output_json:
+                out_tc: dict = {
+                    "overall": {"accuracy": tc_result.overall.accuracy},
+                    "across_topic": {"accuracy": tc_result.across_topic.accuracy},
+                    "within_topic": {
+                        t: {"accuracy": r.accuracy}
+                        for t, r in tc_result.within_topic.items()
+                    },
+                }
+                typer.echo(json.dumps(out_tc, indent=2))
+            else:
+                typer.echo("\n  Topic-Controlled Evaluation")
+                typer.echo(f"  {'═' * 50}")
+                typer.echo(f"\n  Overall accuracy: {tc_result.overall.accuracy:.1%}")
+                typer.echo(f"  Across-topic accuracy: {tc_result.across_topic.accuracy:.1%}")
+                typer.echo("\n  Within-topic:")
+                for t, r in sorted(tc_result.within_topic.items()):
+                    typer.echo(f"    {t:<25} {r.accuracy:.1%}")
+            return
+        elif train_genre and test_genre:
             from mowen.evaluation import cross_genre_evaluate
             result = cross_genre_evaluate(
                 known, config, train_genre, test_genre,

--- a/core/src/mowen/evaluation.py
+++ b/core/src/mowen/evaluation.py
@@ -575,6 +575,133 @@ def cross_genre_evaluate(
 
 
 # ---------------------------------------------------------------------------
+# Topic-controlled evaluation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TopicControlledResult:
+    """Comparative results from topic-controlled evaluation."""
+
+    within_topic: dict[str, EvaluationResult]  # topic -> result
+    across_topic: EvaluationResult
+    overall: EvaluationResult
+
+
+def topic_controlled_evaluate(
+    documents: list[Document],
+    config: PipelineConfig,
+    *,
+    topic_key: str = "topic",
+    progress_callback: ProgressCallback | None = None,
+) -> TopicControlledResult:
+    """Evaluate with topic controls to measure topic confounding.
+
+    Produces three sets of results:
+
+    * **within-topic**: LOO for each topic separately
+    * **across-topic**: for each topic, train on other topics, test on it
+    * **overall**: standard LOO ignoring topics
+
+    Documents must have ``metadata[topic_key]`` set and an author.
+
+    Parameters
+    ----------
+    documents:
+        All documents with topic metadata.
+    config:
+        Pipeline configuration.
+    topic_key:
+        Metadata key for topic labels.
+    progress_callback:
+        Optional ``(fraction, message)`` callback.
+    """
+    # Validate
+    for doc in documents:
+        if topic_key not in doc.metadata:
+            raise EvaluationError(
+                f"Document {doc.title!r} missing metadata key "
+                f"{topic_key!r}"
+            )
+        if not doc.author:
+            raise EvaluationError(
+                f"Document {doc.title!r} has no author"
+            )
+
+    # Group by topic
+    by_topic: dict[str, list[Document]] = {}
+    for doc in documents:
+        topic = doc.metadata[topic_key]
+        by_topic.setdefault(topic, []).append(doc)
+
+    topics = sorted(by_topic.keys())
+
+    # Within-topic: LOO per topic
+    within: dict[str, EvaluationResult] = {}
+    for i, topic in enumerate(topics):
+        topic_docs = by_topic[topic]
+        topic_authors = {d.author for d in topic_docs}
+        if len(topic_authors) < 2 or len(topic_docs) < 2:
+            logger.warning(
+                "Topic %r skipped for within-topic: "
+                "insufficient authors or documents",
+                topic,
+            )
+            continue
+        if progress_callback:
+            frac = i / (len(topics) * 2)
+            progress_callback(frac, f"Within-topic: {topic}")
+        within[topic] = leave_one_out(topic_docs, config)
+
+    # Across-topic: for each topic, train on others, test on it
+    across_folds: list[FoldResult] = []
+    for i, topic in enumerate(topics):
+        test_docs = by_topic[topic]
+        train_docs = [
+            d for t, docs in by_topic.items()
+            for d in docs if t != topic
+        ]
+        train_authors = {d.author for d in train_docs}
+        if len(train_authors) < 2:
+            logger.warning(
+                "Topic %r skipped for across-topic: "
+                "training set has < 2 authors",
+                topic,
+            )
+            continue
+        if progress_callback:
+            frac = 0.5 + i / (len(topics) * 2)
+            progress_callback(frac, f"Across-topic: {topic}")
+
+        results = Pipeline(config).execute(train_docs, test_docs)
+        preds = [
+            _make_prediction(r, test_docs[j].author or "")
+            for j, r in enumerate(results)
+        ]
+        across_folds.append(FoldResult(fold_index=i, predictions=preds))
+
+    across = _compute_metrics(across_folds) if across_folds else EvaluationResult(
+        fold_results=[], accuracy=0.0, per_author=[],
+        macro_precision=0.0, macro_recall=0.0, macro_f1=0.0,
+        confusion_matrix={},
+    )
+
+    # Overall: standard LOO
+    if progress_callback:
+        progress_callback(0.9, "Overall LOO")
+    overall = leave_one_out(documents, config)
+
+    if progress_callback:
+        progress_callback(1.0, "Evaluation complete")
+
+    return TopicControlledResult(
+        within_topic=within,
+        across_topic=across,
+        overall=overall,
+    )
+
+
+# ---------------------------------------------------------------------------
 # CSV export
 # ---------------------------------------------------------------------------
 

--- a/tests/test_topic_controlled.py
+++ b/tests/test_topic_controlled.py
@@ -1,0 +1,97 @@
+"""Tests for topic-controlled evaluation."""
+
+import pytest
+
+from mowen.evaluation import topic_controlled_evaluate
+from mowen.exceptions import EvaluationError
+from mowen.pipeline import PipelineConfig
+from mowen.types import Document
+
+
+def _config():
+    return PipelineConfig(
+        event_drivers=[{"name": "character_ngram", "params": {"n": 3}}],
+        distance_function={"name": "cosine"},
+        analysis_method={"name": "nearest_neighbor"},
+    )
+
+
+def _make_topic_docs():
+    """Two topics, two authors, 2 docs each per topic."""
+    return [
+        Document(
+            text="The government requires strong institutions.",
+            author="Hamilton", title="h_pol",
+            metadata={"topic": "politics"},
+        ),
+        Document(
+            text="Federal power ensures defense.",
+            author="Hamilton", title="h_pol2",
+            metadata={"topic": "politics"},
+        ),
+        Document(
+            text="Separation of powers prevents tyranny.",
+            author="Madison", title="m_pol",
+            metadata={"topic": "politics"},
+        ),
+        Document(
+            text="A republic guards against faction.",
+            author="Madison", title="m_pol2",
+            metadata={"topic": "politics"},
+        ),
+        Document(
+            text="Economics drives trade between nations.",
+            author="Hamilton", title="h_econ",
+            metadata={"topic": "economics"},
+        ),
+        Document(
+            text="Banks and currency stabilize the economy.",
+            author="Hamilton", title="h_econ2",
+            metadata={"topic": "economics"},
+        ),
+        Document(
+            text="Agriculture is the foundation of wealth.",
+            author="Madison", title="m_econ",
+            metadata={"topic": "economics"},
+        ),
+        Document(
+            text="Land ownership drives economic independence.",
+            author="Madison", title="m_econ2",
+            metadata={"topic": "economics"},
+        ),
+    ]
+
+
+class TestTopicControlledEvaluation:
+    def test_basic_topic_controlled(self):
+        docs = _make_topic_docs()
+        result = topic_controlled_evaluate(docs, _config())
+        assert result.overall is not None
+        assert result.across_topic is not None
+        assert len(result.within_topic) == 2
+        assert "politics" in result.within_topic
+        assert "economics" in result.within_topic
+
+    def test_overall_matches_loo(self):
+        """Overall result should be same as standard LOO."""
+        from mowen.evaluation import leave_one_out
+        docs = _make_topic_docs()
+        tc = topic_controlled_evaluate(docs, _config())
+        loo = leave_one_out(docs, _config())
+        assert tc.overall.accuracy == pytest.approx(loo.accuracy)
+
+    def test_missing_topic_raises(self):
+        docs = [
+            Document(text="text", author="A", title="d1"),
+            Document(text="text", author="B", title="d2"),
+        ]
+        with pytest.raises(EvaluationError, match="missing metadata"):
+            topic_controlled_evaluate(docs, _config())
+
+    def test_accuracies_in_range(self):
+        docs = _make_topic_docs()
+        result = topic_controlled_evaluate(docs, _config())
+        assert 0.0 <= result.overall.accuracy <= 1.0
+        assert 0.0 <= result.across_topic.accuracy <= 1.0
+        for r in result.within_topic.values():
+            assert 0.0 <= r.accuracy <= 1.0


### PR DESCRIPTION
## Summary
- `TopicControlledResult` with within-topic, across-topic, and overall results
- `topic_controlled_evaluate()` in evaluation.py
- CLI `--topic-controlled` flag with JSON and text output

## Test plan
- [x] 4 tests (basic, matches LOO, missing metadata, range)
- [x] Full suite: 789 passed