### PR TITLE
Fix missing column error on existing databases

### DIFF
--- a/server/src/mowen_server/db.py
+++ b/server/src/mowen_server/db.py
@@ -3,7 +3,7 @@
 from collections.abc import Generator
 
 from fastapi import HTTPException
-from sqlalchemy import Engine, create_engine
+from sqlalchemy import Engine, create_engine, inspect, text
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
 engine: Engine | None = None
@@ -28,7 +28,37 @@ def init_db(database_url: str) -> None:
     engine = create_engine(database_url, connect_args=connect_args)
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
+    import mowen_server.models  # noqa: F401 — ensure models are registered
+
     Base.metadata.create_all(bind=engine)
+    _migrate_missing_columns(engine)
+
+
+def _migrate_missing_columns(eng: Engine) -> None:
+    """Add any columns present in models but missing from the database.
+
+    This is a lightweight forward-only migration so that existing SQLite
+    databases pick up new columns without requiring a manual schema change.
+    """
+    inspector = inspect(eng)
+    for table_name, table in Base.metadata.tables.items():
+        if not inspector.has_table(table_name):
+            continue
+        existing = {col["name"] for col in inspector.get_columns(table_name)}
+        for column in table.columns:
+            if column.name not in existing:
+                col_type = column.type.compile(dialect=eng.dialect)
+                nullable = "NULL" if column.nullable else "NOT NULL"
+                default = ""
+                if column.default is not None and column.default.is_scalar:
+                    default = f" DEFAULT {column.default.arg!r}"
+                with eng.begin() as conn:
+                    conn.execute(
+                        text(
+                            f"ALTER TABLE {table_name} "
+                            f"ADD COLUMN {column.name} {col_type} {nullable}{default}"
+                        )
+                    )
 
 
 def get_db() -> Generator[Session, None, None]:


### PR DESCRIPTION
## Summary
- Adds lightweight forward-only schema migration to `init_db()` that detects columns present in ORM models but missing from the database and issues `ALTER TABLE ADD COLUMN` for each
- Fixes `sqlite3.OperationalError: no such column: experiments.verification_threshold` on databases created before the verification feature was added
- Explicitly imports models in `init_db()` to ensure metadata is populated regardless of import order

## Test plan
- [x] Verified migration correctly adds `lower_is_better` and `verification_threshold` to an old-schema database
- [x] Verified existing rows get correct defaults (lower_is_better=1, verification_threshold=NULL)
- [x] All 31 server API tests pass